### PR TITLE
initial structure and CI/CD

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -1,0 +1,136 @@
+name: Build & Release
+
+on:
+  workflow_call:
+    inputs:
+      architectures:
+        description: A JSON list of GOARCH values for which to build
+        default: '["amd64", "arm64"]'
+        required: false
+        type: string
+      push-container-image:
+        description: Whether to push the resulting container image to the registry
+        default: false
+        required: false
+        type: boolean
+      create-release:
+        description: Whether to create a Github release and attach the artifacts to it
+        default: false
+        required: false
+        type: boolean
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-go:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: ${{ fromJson(inputs.architectures) }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v8
+
+      - name: Run tests
+        run: |-
+          go test -v ./...
+
+      - name: Build
+        run: |-
+          mkdir -p $GITHUB_WORKSPACE/dist
+
+          CGO_ENABLED=0 \
+          GOARCH=${{ matrix.arch }} \
+          GOOS=linux \
+            go build \
+            -ldflags '\
+              -s -w \
+              -buildid=${{ github.sha }} \
+              -X main.version=${{ github.ref_name }} \
+              -X main.commit=${{ github.sha }} \
+            ' \
+            -trimpath -mod=readonly \
+            -o $GITHUB_WORKSPACE/dist/multigres-operator-${{ matrix.arch }} \
+            ./cmd/multigres-operator
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: multigres-operator-${{matrix.arch}}
+          path: dist/*
+
+  build-push-container:
+    needs: [ build-go ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract container metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch,prefix=
+            type=ref,event=tag,prefix=
+            type=sha,format=short,prefix=
+            type=sha,format=long,prefix=
+
+      - uses: actions/download-artifact@v5
+        with:
+          pattern: multigres-operator-*
+          path: dist/
+
+      - name: Build and push container image
+        id: build-and-push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Containerfile
+          platforms: linux/${{ join(fromJson(inputs.architectures), ',linux/') }}
+          push: ${{ inputs.push-container-image }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  create-release:
+    needs: [ build-go ]
+    runs-on: ubuntu-latest
+    if: ${{ inputs.create-release }}
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          pattern: "*"
+          path: dist/
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/**

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,16 @@
+name: Build main
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  run:
+    uses: ./.github/workflows/build-and-release.yaml
+    with:
+      push-container-image: true

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,12 @@
+name: Run checks
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  run:
+    uses: ./.github/workflows/build-and-release.yaml

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -1,0 +1,17 @@
+name: Release tag
+
+on:
+  push:
+    tags:
+      - '**'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  run:
+    uses: ./.github/workflows/build-and-release.yaml
+    with:
+      push-container-image: true
+      create-release: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# direnv
+.direnv/
+
+# nix
+result
+result-*
+
+# generic
+dist/

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -1,0 +1,3 @@
+version = "2"
+[formatters]
+enable = [ "gofumpt", "golines" ]

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,13 @@
+FROM --platform=$BUILDPLATFORM alpine:3.22.1 AS build
+ARG TARGETOS
+ARG TARGETARCH
+
+COPY dist dist
+RUN cp dist/multigres-operator-${TARGETARCH}/multigres-operator-${TARGETARCH} multigres-operator
+RUN chmod +x multigres-operator
+
+FROM alpine:3.22.1
+
+COPY --from=build multigres-operator multigres-operator
+
+ENTRYPOINT [ "./multigres-operator" ]

--- a/cmd/multigres-operator/main.go
+++ b/cmd/multigres-operator/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("TODO")
+}

--- a/cmd/multigres-operator/main_test.go
+++ b/cmd/multigres-operator/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestNothing(t *testing.T) {
+	// TODO: write real tests
+}

--- a/devshell.nix
+++ b/devshell.nix
@@ -1,0 +1,13 @@
+{ pkgs }:
+pkgs.mkShell {
+  # Add build dependencies
+  packages = with pkgs; [ go ];
+
+  # Add environment variables
+  env = { };
+
+  # Load custom bash code
+  shellHook = ''
+
+  '';
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "blueprint": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1758687491,
+        "narHash": "sha256-sy8Q+MfBe+MZzYj4MJwBDe4lkLnmhy1POO86hWZgqO8=",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "rev": "7ecaeb70f63d14a397c73b38f57177894bb795c8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "blueprint",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1758427187,
+        "narHash": "sha256-pHpxZ/IyCwoTQPtFIAG2QaxuSm8jWzrzBGjwQZIttJc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "blueprint": "blueprint",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,13 @@
+{
+  description = "Flake for multigres-operator";
+
+  # Add all your dependencies here
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
+    blueprint.url = "github:numtide/blueprint";
+    blueprint.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  # Load the blueprint
+  outputs = inputs: inputs.blueprint { inherit inputs; };
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/numtide/multigres-operator
+
+go 1.25.0


### PR DESCRIPTION
* brings CI/CD pipeline over from temporary repository
* adjusted go module location to root
* simplified build targets (just one hardcoded now)
* added build-time variables providing `version` and `commit`

here's an [example release](https://github.com/numtide/multigres-operator/releases/tag/test)
here's an [example container image](https://github.com/numtide/multigres-operator/pkgs/container/multigres-operator)